### PR TITLE
Better serialization of number literals over NLog/Log4Net.

### DIFF
--- a/src/Seq.Client.Log4Net/Client/Log4Net/LoggingEventFormatter.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/LoggingEventFormatter.cs
@@ -141,6 +141,9 @@ namespace Seq.Client.Log4Net
                 return;
             }
 
+			// Attempt to convert the object (if a string) to it's literal type (int/decimal/date)
+            value = GetValueAsLiteral(value);
+			
             Action<object, TextWriter> writer;
             if (_literalWriters.TryGetValue(value.GetType(), out writer))
             {
@@ -252,6 +255,33 @@ namespace Seq.Client.Log4Net
             }
 
             return s;
+        }
+		
+		/// <summary>
+        /// GetValueAsLiteral attempts to transform the (string) object into a literal type prior to json serialization.
+        /// </summary>
+        /// <param name="value">The value to be transformed/parsed.</param>
+        /// <returns>A translated representation of the literal object type instead of a string.</returns>
+        static object GetValueAsLiteral(object value)
+        {
+            if (!(value is string))
+                return value;
+
+            var str = value.ToString();
+
+            long longBuffer;
+            if (long.TryParse(str, out longBuffer))
+                return longBuffer;
+
+            decimal decimalBuffer;
+            if (decimal.TryParse(str, out decimalBuffer))
+                return decimalBuffer;
+
+            DateTime dateBuffer;
+            if (DateTime.TryParse(str, out dateBuffer))
+                return dateBuffer;
+
+            return value;
         }
     }
 }

--- a/src/Seq.Client.Log4Net/Client/Log4Net/LoggingEventFormatter.cs
+++ b/src/Seq.Client.Log4Net/Client/Log4Net/LoggingEventFormatter.cs
@@ -269,14 +269,12 @@ namespace Seq.Client.Log4Net
 
             var str = value.ToString();
 
-            long longBuffer;
-            if (long.TryParse(str, out longBuffer))
-                return longBuffer;
-
+            // All number literals are serialized as a decimal so ignore other number types.
             decimal decimalBuffer;
             if (decimal.TryParse(str, out decimalBuffer))
                 return decimalBuffer;
 
+            // Standardize on dates if/when possible.
             DateTime dateBuffer;
             if (DateTime.TryParse(str, out dateBuffer))
                 return dateBuffer;

--- a/src/Seq.Client.NLog/Client/NLog/LogEventInfoFormatter.cs
+++ b/src/Seq.Client.NLog/Client/NLog/LogEventInfoFormatter.cs
@@ -298,14 +298,12 @@ namespace Seq.Client.NLog
 
             var str = value.ToString();
 
-            long longBuffer;
-            if (long.TryParse(str, out longBuffer))
-                return longBuffer;
-
+            // All number literals are serialized as a decimal so ignore other number types.
             decimal decimalBuffer;
             if (decimal.TryParse(str, out decimalBuffer))
                 return decimalBuffer;
 
+            // Standardize on dates if/when possible.
             DateTime dateBuffer;
             if (DateTime.TryParse(str, out dateBuffer))
                 return dateBuffer;

--- a/src/Seq.Client.NLog/Client/NLog/LogEventInfoFormatter.cs
+++ b/src/Seq.Client.NLog/Client/NLog/LogEventInfoFormatter.cs
@@ -170,6 +170,9 @@ namespace Seq.Client.NLog
                 return;
             }
 
+            // Attempt to convert the object (if a string) to its literal type (int/decimal/date)
+            value = GetValueAsLiteral(value);
+
             Action<object, TextWriter> writer;
             if (LiteralWriters.TryGetValue(value.GetType(), out writer))
             {
@@ -281,6 +284,33 @@ namespace Seq.Client.NLog
             }
 
             return s;
+        }
+
+        /// <summary>
+        /// GetValueAsLiteral attempts to transform the (string) object into a literal type prior to json serialization.
+        /// </summary>
+        /// <param name="value">The value to be transformed/parsed.</param>
+        /// <returns>A translated representation of the literal object type instead of a string.</returns>
+        static object GetValueAsLiteral(object value)
+        {
+            if (!(value is string))
+                return value;
+
+            var str = value.ToString();
+
+            long longBuffer;
+            if (long.TryParse(str, out longBuffer))
+                return longBuffer;
+
+            decimal decimalBuffer;
+            if (decimal.TryParse(str, out decimalBuffer))
+                return decimalBuffer;
+
+            DateTime dateBuffer;
+            if (DateTime.TryParse(str, out dateBuffer))
+                return dateBuffer;
+
+            return value;
         }
     }
 }


### PR DESCRIPTION
Added and called a simple helper method to attempt to transform strings into literal types before writing them the the Text/StreamWriter.

This makes all numbers sent over NLog/Log4Net serialize properly regardless of input type.